### PR TITLE
Update the function name Dial in README to DialContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ go func() {
 }()
 ```
 
-If you are using an `http.Transport`, you can use this cache by specifying a `Dial` function:
+If you are using an `http.Transport`, you can use this cache by specifying a `DialContext` function:
 
 ```go
 r := &Resolver{}


### PR DESCRIPTION
## Overview
Update the function name `Dial` described in README.md to `DialContext`.

## Reason
The sample code for using `http.Transport` defines `DialContext`. But the description of the code is

> you can use this cache by specifying a `Dial` function

`Dial` function is deprecated. So it's better not to mention the deprecated and unused function.
https://godoc.org/net/http#Transport

## When merging this PR
The document will be more accurate.