### PR TITLE
Fix race condition on delete

### DIFF
--- a/dnscache.go
+++ b/dnscache.go
@@ -51,14 +51,22 @@ func (r *Resolver) Refresh(clearUnused bool) {
 	r.once.Do(r.init)
 	r.mu.RLock()
 	update := make([]string, 0, len(r.cache))
+	del := make([]string, 0, len(r.cache))
 	for key, entry := range r.cache {
 		if entry.used {
 			update = append(update, key)
 		} else if clearUnused {
-			delete(r.cache, key)
+			del = append(del, key)
 		}
 	}
 	r.mu.RUnlock()
+
+	for _, key := range del {
+		r.mu.Lock()
+		delete(r.cache, key)
+		r.mu.Unlock()
+	}
+
 	for _, key := range update {
 		r.update(context.Background(), key, false)
 	}

--- a/dnscache.go
+++ b/dnscache.go
@@ -61,9 +61,11 @@ func (r *Resolver) Refresh(clearUnused bool) {
 	}
 	r.mu.RUnlock()
 
-	for _, key := range del {
+	if len(del) > 0 {
 		r.mu.Lock()
-		delete(r.cache, key)
+		for _, key := range del {
+			delete(r.cache, key)
+		}
 		r.mu.Unlock()
 	}
 

--- a/dnscache_test.go
+++ b/dnscache_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestResolver_LookupHost(t *testing.T) {
@@ -54,6 +55,42 @@ func TestClearCache(t *testing.T) {
 	if e := r.cache["hgoogle.com"]; e != nil {
 		t.Error("cache entry is not cleared")
 	}
+}
+
+func TestRaceOnDelete(t *testing.T) {
+	r := &Resolver{}
+	ls := make(chan bool)
+	rs := make(chan bool)
+
+	go func() {
+		for {
+			select {
+			case <-ls:
+				return
+			default:
+				r.LookupHost(context.Background(), "google.com")
+				time.Sleep(2 * time.Millisecond)
+			}
+		}
+	}()
+
+	go func() {
+		for {
+			select {
+			case <-rs:
+				return
+			default:
+				r.Refresh(true)
+				time.Sleep(time.Millisecond)
+			}
+		}
+	}()
+
+	time.Sleep(1 * time.Second)
+
+	ls <- true
+	rs <- true
+
 }
 
 func Example() {


### PR DESCRIPTION
Seeing a race condition when calling Refresh and LookupHost at the same time.

Looks like this is caused by a `delete` when only a Read lock is held. 

Fix is to delay the delete until once the read lock has been released and then grab a write lock to perform the delete operations.

```
go test -timeout 30s github.com/rs/dnscache -run ^(TestRaceOnDelete)$ -v -race -count=1

=== RUN   TestRaceOnDelete
==================
WARNING: DATA RACE
Read at 0x00c00011c000 by goroutine 8:
  runtime.mapaccess2_faststr()
      /usr/local/go/src/runtime/map_faststr.go:101 +0x0
  github.com/rs/dnscache.(*Resolver).load()
      /Users/otoolec/code/golang/src/github.com/rs/dnscache/dnscache.go:160 +0xab
  github.com/rs/dnscache.(*Resolver).lookup()
      /Users/otoolec/code/golang/src/github.com/rs/dnscache/dnscache.go:77 +0x6a
  github.com/rs/dnscache.(*Resolver).LookupHost()
      /Users/otoolec/code/golang/src/github.com/rs/dnscache/dnscache.go:44 +0xf7
  github.com/rs/dnscache.TestRaceOnDelete.func1()
      /Users/otoolec/code/golang/src/github.com/rs/dnscache/dnscache_test.go:73 +0x7b

Previous write at 0x00c00011c000 by goroutine 9:
  runtime.mapdelete_faststr()
      /usr/local/go/src/runtime/map_faststr.go:281 +0x0
  github.com/rs/dnscache.(*Resolver).Refresh()
      /Users/otoolec/code/golang/src/github.com/rs/dnscache/dnscache.go:58 +0x3fb
  github.com/rs/dnscache.TestRaceOnDelete.func2()
      /Users/otoolec/code/golang/src/github.com/rs/dnscache/dnscache_test.go:85 +0x3f

Goroutine 8 (running) created at:
  github.com/rs/dnscache.TestRaceOnDelete()
      /Users/otoolec/code/golang/src/github.com/rs/dnscache/dnscache_test.go:67 +0x105
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:827 +0x162

Goroutine 9 (running) created at:
  github.com/rs/dnscache.TestRaceOnDelete()
      /Users/otoolec/code/golang/src/github.com/rs/dnscache/dnscache_test.go:79 +0x131
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:827 +0x162
==================
--- FAIL: TestRaceOnDelete (1.01s)
    /Users/otoolec/code/golang/src/github.com/rs/dnscache/testing.go:771: race detected during execution of test
FAIL
FAIL	github.com/rs/dnscache	1.027s
Error: Tests failed.
```