### PR TITLE
documentation: net package functions + DialContext usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,17 @@ If you are using an `http.Transport`, you can use this cache by specifying a `Di
 r := &dnscache.Resolver{}
 t := &http.Transport{
     DialContext: func(ctx context.Context, network string, addr string) (conn net.Conn, err error) {
-        separator := strings.LastIndex(addr, ":")
-        ips, err := r.LookupHost(ctx, addr[:separator])
+        host, port, err := net.SplitHostPort(addr)
+        if err != nil {
+            return nil, err
+        }
+        ips, err := r.LookupHost(ctx, host)
         if err != nil {
             return nil, err
         }
         for _, ip := range ips {
-            conn, err = net.Dial(network, ip+addr[separator:])
+            var dialer net.Dialer
+            conn, err = dialer.DialContext(ctx, network, net.JoinHostPort(ip, port))
             if err == nil {
                 break
             }

--- a/example_test.go
+++ b/example_test.go
@@ -5,20 +5,23 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"strings"
 )
 
 func Example() {
 	r := &Resolver{}
 	t := &http.Transport{
 		DialContext: func(ctx context.Context, network string, addr string) (conn net.Conn, err error) {
-			separator := strings.LastIndex(addr, ":")
-			ips, err := r.LookupHost(ctx, addr[:separator])
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+			ips, err := r.LookupHost(ctx, host)
 			if err != nil {
 				return nil, err
 			}
 			for _, ip := range ips {
-				conn, err = net.Dial(network, ip+addr[separator:])
+				var dialer net.Dialer
+				conn, err = dialer.DialContext(ctx, network, net.JoinHostPort(ip, port))
 				if err == nil {
 					break
 				}


### PR DESCRIPTION
Hello,
Just a quick patch for documentation:
* usage of net package functions for parsing and joining host and port
* usage of DialContext to propagate context into dialing part (could be usefull if parent context is cancelled)

Signed-off-by: Romain Beuque <romain.beuque@corp.ovh.com>