### PR TITLE
README.md: imporove example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ If you are using an `http.Transport`, you can use this cache by specifying a `Di
 r := &dnscache.Resolver{}
 t := &http.Transport{
     DialContext: func(ctx context.Context, network string, addr string) (conn net.Conn, err error) {
-        host, port, err := net.SplitHostPort(addr)
+        // addr has form host:port and the port is 80 by default
+        colonPos := strings.LastIndexByte(addr, ':')
+        host := addr[:colonPos]
+        ips, err := resolver.LookupHost(ctx, host)
         if err != nil {
             return nil, err
         }
-        ips, err := r.LookupHost(ctx, host)
-        if err != nil {
-            return nil, err
-        }
+        port := addr[colonPos + 1:]
         for _, ip := range ips {
             var dialer net.Dialer
             conn, err = dialer.DialContext(ctx, network, net.JoinHostPort(ip, port))


### PR DESCRIPTION
The `net.SplitHostPort()` expects that addr is a host with port but:
* The host can be not just a domain but also IPv4 or IPv6 address
* Port may be undefined

In our case port is always specified so we can safely take a last part after the colon ':' and this will work even for IPv6.
Also in fact we expect only a domain and if the addr is already IP then the DNS lookup can be skipped.
You can add a check if host is already an IP and skip it but I didn't found an easy solution and I expect this to be a rare case.